### PR TITLE
Skip zero turbulence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 preferences.xml
 
 report.xls
+.idea/*
+res PCWG.py

--- a/Analysis.py
+++ b/Analysis.py
@@ -115,7 +115,7 @@ class Analysis:
         self.powerCurvePadder = PadderFactory().generate(config.powerCurvePaddingMode,self.actualPower, self.inputHubWindSpeed, self.hubTurbulence, self.dataCount)
 
         powerCurveConfig = configuration.PowerCurveConfiguration(self.relativePath.convertToAbsolutePath(config.specifiedPowerCurve))
-        self.specifiedPowerCurve = turbine.PowerCurve(powerCurveConfig.powerCurveLevels, powerCurveConfig.powerCurveDensity, self.rotorGeometry, "Specified Power", "Specified Turbulence")               
+        self.specifiedPowerCurve = turbine.PowerCurve(powerCurveConfig.powerCurveLevels, powerCurveConfig.powerCurveDensity, self.rotorGeometry, "Specified Power", "Specified Turbulence", turbulenceRenormalisation = self.turbRenormActive)
 
         if self.densityCorrectionActive:
             if self.hasDensity:
@@ -428,7 +428,8 @@ class Analysis:
 
         powerLevels = self.powerCurvePadder.pad(dfPowerLevels,cutInWindSpeed,cutOutWindSpeed,ratedPower)
 
-        return turbine.PowerCurve(powerLevels, self.specifiedPowerCurve.referenceDensity, self.rotorGeometry, self.actualPower, self.hubTurbulence, wsCol = self.inputHubWindSpeed, countCol = self.dataCount)
+        return turbine.PowerCurve(powerLevels, self.specifiedPowerCurve.referenceDensity, self.rotorGeometry, self.actualPower,
+                                  self.hubTurbulence, wsCol = self.inputHubWindSpeed, countCol = self.dataCount, turbulenceRenormalisation=self.turbRenormActive)
 
     def calculatePowerDeviationMatrix(self, power, filterMode):
 

--- a/aep.py
+++ b/aep.py
@@ -82,6 +82,8 @@ class WindSpeedDistribution(XmlBase):
             distribution[BinCentre] = self.getNodeFloat(node, 'BinValue')
 
         self.df = pd.Series(distribution)
+        if len(self.df) < 1:
+            raise Exception("Error reading distribution file - no 'Bin' nodes detected...")
         self.cumulative  = self.df.cumsum()
         self.cumulativeFunction = interp1d(self.cumulative.index, self.cumulative,bounds_error=False, fill_value=0.0)#,kind = 'cubic')
         self.binSize = self.df.index[2]-self.df.index[1]

--- a/reporting.py
+++ b/reporting.py
@@ -42,7 +42,7 @@ class report:
 
             rowAfterCurves = max(rowsAfterCurves) + 5
             sh.write(rowAfterCurves-2, 0, "Power Curves Interpolated to Specified Bins:", self.bold_style)
-            specifiedLevels = analysis.specifiedPowerCurve.powerCurveLevels.keys()
+            specifiedLevels = analysis.specifiedPowerCurve.powerCurveLevels.index
             if analysis.hasShear: self.reportInterpolatedPowerCurve(sh, rowAfterCurves, 4, 'Inner', analysis.innerMeasuredPowerCurve, specifiedLevels)
             self.reportInterpolatedPowerCurve(sh, rowAfterCurves, 8, 'InnerTurbulence', analysis.innerTurbulenceMeasuredPowerCurve, specifiedLevels)
             if analysis.hasShear: self.reportInterpolatedPowerCurve(sh, rowAfterCurves, 12, 'Outer', analysis.outerMeasuredPowerCurve, specifiedLevels)
@@ -399,21 +399,21 @@ class report:
         sh.col(columnOffset + 2).width = 256 * 15 
         sh.col(columnOffset + 3).width = 256 * 15
         sh.col(columnOffset + 4).width = 256 * 5
-        
-        sh.write(rowOffset + 1, columnOffset + 1, "Wind Speed", self.bold_style)
-        sh.write(rowOffset + 1, columnOffset + 2, "Power", self.bold_style)
-        sh.write(rowOffset + 1, columnOffset + 3, "Turbulence", self.bold_style)
 
-        count = 1
-        
-        for windSpeed in sorted(powerCurve.powerCurveLevels):
+        countCol = 1
+        for colname in powerCurve.powerCurveLevels.columns:
+            sh.write(rowOffset + 1, columnOffset + countCol, colname, self.bold_style)
+            countCol+=1
 
-            sh.write(rowOffset + count + 1, columnOffset + 1, windSpeed, self.two_dp_style)
-            sh.write(rowOffset + count + 1, columnOffset + 2, powerCurve.powerCurveLevels[windSpeed], self.no_dp_style)
-            sh.write(rowOffset + count + 1, columnOffset + 3, powerCurve.turbulenceLevels[windSpeed], self.percent_no_dp_style)
+        countRow = 1
+        for windSpeed in powerCurve.powerCurveLevels.index:
+            countCol = 1
+            for colname in powerCurve.powerCurveLevels.columns:
+                sh.write(rowOffset + countRow + 1, columnOffset + countCol, powerCurve.powerCurveLevels[colname][windSpeed], self.no_dp_style)
+                countCol += 1
+            countRow += 1
 
-            count += 1
-        return count
+        return countRow
 
     def reportInterpolatedPowerCurve(self, sh, rowOffset, columnOffset, name, powerCurve, levels):
 

--- a/turbine.py
+++ b/turbine.py
@@ -9,7 +9,8 @@ import pandas as pd
 
 class PowerCurve:
 
-    def __init__(self, powerCurveLevels, referenceDensity, rotorGeometry, powerCol, turbCol, wsCol = None, countCol = None, fixedTurbulence = None, ratedPower = None):
+    def __init__(self, powerCurveLevels, referenceDensity, rotorGeometry, powerCol, turbCol, wsCol = None,
+                 countCol = None, fixedTurbulence = None, ratedPower = None,turbulenceRenormalisation=True):
         
         self.actualPower = powerCol #strings defining column names
         self.inputHubWindSpeed = wsCol
@@ -40,10 +41,11 @@ class PowerCurve:
 
         self.turbulenceFunction = self.createFunction(powerCurveLevels[self.hubTurbulence], ws_data)
 
-        keys = sorted(powerCurveLevels[self.actualPower].keys())
-        integrationRange = IntegrationRange(0.0, 100.0, 0.1)
-        self.zeroTurbulencePowerCurve = ZeroTurbulencePowerCurve(keys, self.getArray(powerCurveLevels[self.actualPower], keys), self.getArray(powerCurveLevels[self.hubTurbulence], keys), integrationRange, self.availablePower)
-        self.simulatedPower = SimulatedPower(self.zeroTurbulencePowerCurve, integrationRange)
+        if turbulenceRenormalisation:
+            keys = sorted(powerCurveLevels[self.actualPower].keys())
+            integrationRange = IntegrationRange(0.0, 100.0, 0.1)
+            self.zeroTurbulencePowerCurve = ZeroTurbulencePowerCurve(keys, self.getArray(powerCurveLevels[self.actualPower], keys), self.getArray(powerCurveLevels[self.hubTurbulence], keys), integrationRange, self.availablePower)
+            self.simulatedPower = SimulatedPower(self.zeroTurbulencePowerCurve, integrationRange)
 
     def getRatedPower(self, ratedPower, powerCurveLevels):
 


### PR DESCRIPTION
speed up calculation and avoid errors where data count is low by removing the calculation of a zero turbulence curve.